### PR TITLE
ias: Updating ias.service to include new env vars.

### DIFF
--- a/ias.service
+++ b/ias.service
@@ -14,6 +14,7 @@ Description=ias weston compositor
 
 [Service]
 Environment="XDG_CONFIG_HOME=/usr/share/xdg/weston" "XDG_RUNTIME_DIR=/run/ias"
+Environment="LIBVA_DRIVERS_PATH=/usr/lib64/dri/" "LIBVA_DRIVER_NAME=iHD"
 User=ias
 Group=weston-launch
 RuntimeDirectory=ias


### PR DESCRIPTION
If remote display is to be used, then IAS requires
LIBVA_DRIVERS_PATH and LIBVA_DRIVER_NAME to be set.

Signed-off-by: Satyeshwar Singh <satyeshwar.singh@intel.com>